### PR TITLE
Catalog updates 20250120

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,6 +2,6 @@
         org.scicloj/kindly {:mvn/version "4-beta14"}
         org.scicloj/kindly-advice {:mvn/version "1-beta12"}
         org.scicloj/kind-portal {:mvn/version "1-beta3"}
-        org.scicloj/clay {:mvn/version "2-beta27"}
-        org.scicloj/noj {:mvn/version "2-alpha12.1"}}
+        org.scicloj/clay {:mvn/version "2-beta28"}
+        org.scicloj/noj {:mvn/version "2-beta5"}}
  :paths ["src" "notebooks"]}

--- a/notebooks/kinds.clj
+++ b/notebooks/kinds.clj
@@ -162,7 +162,19 @@ hello-hiccup
   (kind/code
    "(defn f [x] (+  x 9))")])
 
-;; A more detailed example:
+;; Scittle and Reagent kinds are recognized automatically
+;; inside Hiccup:
+
+(kind/hiccup
+ [:div
+  ;; recognized as `kind/scittle`
+  '(defn g [x]
+     (+ x 9))
+  ;; recognized as `kind/reagent`
+  ['(fn []
+      [:p (g 11)])]])
+
+;; A more detailed nesting example:
 (kind/hiccup
  [:div {:style {:background "#f5f3ff"
                 :border "solid"}}
@@ -202,12 +214,13 @@ hello-hiccup
       kind/vega-lite)
 
   [:hr]
-  [:pre [:code "kind/reagent"]]
-  (kind/reagent
-   ['(fn [numbers]
-       [:p {:style {:background "#d4ebe9"}}
-        (pr-str (map inc numbers))])
-    (vec (range 40))])])
+  [:pre [:code "kind/reagent"]
+   [:p "(automatically recognized without annotation)"]]
+  ;; Recognized as `kind/reagent`:
+  ['(fn [numbers]
+      [:p {:style {:background "#d4ebe9"}}
+       (pr-str (map inc numbers))])
+   (vec (range 40))]])
 
 
 ;; ## Reagent

--- a/notebooks/kinds.clj
+++ b/notebooks/kinds.clj
@@ -165,6 +165,9 @@ hello-hiccup
 ;; Scittle and Reagent kinds are recognized automatically
 ;; inside Hiccup:
 
+;; * A list beginning with a symbol means `kind/scittle`.
+;; * A vector with a list beginning with a symbol means `kind/reagent`.
+
 (kind/hiccup
  [:div
   ;; recognized as `kind/scittle`

--- a/notebooks/kinds.clj
+++ b/notebooks/kinds.clj
@@ -227,7 +227,7 @@ hello-hiccup
   {:initial-value 9
    :background-color "#d4ebe9"}])
 
-;; The `:html/deps` option can be used to provide additional dependencies.
+;; The `:html/deps` option can be used to provide additional dependencies:
 
 (kind/reagent
  ['(fn []
@@ -250,6 +250,22 @@ hello-hiccup
  {:html/deps [:leaflet]})
 
 ;; Possible ways to specify deps should be documented better soon.
+
+;; ## Scittle
+
+;; With `kind/scittle`, one may specify Clojurescript code to run through
+;; [Scittle](https://github.com/babashka/scittle).
+
+(kind/scittle
+ '(.log js/console "hello"))
+
+(kind/scittle
+ '(defn f [x]
+    (+ x 9)))
+
+(kind/reagent
+ ['(fn []
+     [:p (f 11)])])
 
 ;; ## HTML
 

--- a/notebooks/kinds.clj
+++ b/notebooks/kinds.clj
@@ -227,8 +227,29 @@ hello-hiccup
   {:initial-value 9
    :background-color "#d4ebe9"}])
 
-;; The `:reagent/deps` option can be used to provide additional dependencies.
-;; This should be documented better soon.
+;; The `:html/deps` option can be used to provide additional dependencies.
+
+(kind/reagent
+ ['(fn []
+     [:div {:style {:height "200px"}
+            :ref (fn [el]
+                   (let [m (-> js/L
+                               (.map el)
+                               (.setView (clj->js [51.505 -0.09])
+                                         13))]
+                     (-> js/L
+                         .-tileLayer
+                         (.provider "OpenStreetMap.Mapnik")
+                         (.addTo m))
+                     (-> js/L
+                         (.marker (clj->js [51.5 -0.09]))
+                         (.addTo m)
+                         (.bindPopup "A pretty CSS popup.<br> Easily customizable.")
+                         (.openPopup))))}])]
+ ;; Note we need to mention the dependency:
+ {:html/deps [:leaflet]})
+
+;; Possible ways to specify deps should be documented better soon.
 
 ;; ## HTML
 


### PR DESCRIPTION
* updated Clay version
* added `kind/scittle`
* added an example for using deps in `kind/reagent`
* added an example for automatically recognizing `kind/scittle` and `kind/reagent` inside `kind/hiccup`
(following what @timothypratley did in [kindly-render](https://github.com/scicloj/kindly-render))

cc @behrica 